### PR TITLE
Use README description for package ...

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "preview-finder",
   "main": "./lib/preview-finder",
   "version": "0.5.0",
-  "description": "A short description of your package",
+  "description": "Provides finder in preview.",
   "keywords": [],
   "repository": "https://github.com/basyura/inkdrop-preview-finder",
   "license": "MIT",


### PR DESCRIPTION
So that it shows up in plugin install.

<img width="654" alt="Screen Shot 2020-12-25 at 1 50 42 PM" src="https://user-images.githubusercontent.com/772937/103142467-33af8600-46b8-11eb-8f25-cbfd03baf50f.png">